### PR TITLE
Formatting of output field

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -57,6 +57,8 @@ def main():
         command['command'] = convert_paths(command['command'])
         command['directory'] = convert_paths(command['directory'])
         command['file'] = convert_paths(command['file'])
+        if 'output' in command:
+            command['output'] = convert_paths(command['output'])
         print('{0}/{1}: {2}'.format(index + 1, length, command['file']))
     with open('compile_commands.json', 'w') as output_file:
         json.dump(database, output_file, indent=2)


### PR DESCRIPTION
Clang documentation highlights the use of an optional [output field ](https://clang.llvm.org/docs/JSONCompilationDatabase.html)which was not being parsed before. This PR checks for this optional field and does formatting if it exists. I've included a before and after screenshot below.

Tested on Python 3.11.9 with Kali WSL.

![image](https://github.com/user-attachments/assets/8f89ac35-719a-472c-9604-ae91d8c85109)
![image](https://github.com/user-attachments/assets/6d9bfe0a-8c1b-4fe4-aec5-2594e9819c2c)
